### PR TITLE
feat(context): Add a new context flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,19 @@ If you want to commit generated artifacts in the release commit (e.g. [#96](http
 "release": "git add <file(s) to commit> && standard-version -a"
 ```
 
+### Use a specific context
+
+If you want to use a specific context, you can use `--context <file.json>` or `-c  <file.json>`
+
+Example:
+```json
+{
+  "host": "bitbucket",
+  "owner": "b",
+  "repository": "a"
+}
+```
+
 ### CLI Help
 
 ```sh

--- a/command.js
+++ b/command.js
@@ -57,6 +57,13 @@ module.exports = require('yargs')
     default: defaults.commitAll,
     global: true
   })
+  .option('context', {
+    alias: 'c',
+    describe: 'A filepath of a json that is used to define template variables',
+    type: 'string',
+    default: undefined,
+    global: true
+  })
   .option('silent', {
     describe: 'Don\'t print logs and errors',
     type: 'boolean',

--- a/context.json
+++ b/context.json
@@ -1,0 +1,5 @@
+{
+  "host": "bitbucket",
+  "owner": "b",
+  "repository": "a"
+}

--- a/index.js
+++ b/index.js
@@ -164,6 +164,10 @@ function bumpVersion (releaseAs, callback) {
 }
 
 function outputChangelog (argv, cb) {
+  var templateContext
+  if (argv.context) {
+    templateContext = require(path.resolve(process.cwd(), argv.context))
+  }
   createIfMissing(argv)
   var header = '# Change Log\n\nAll notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.\n'
   var oldContent = fs.readFileSync(argv.infile, 'utf-8')
@@ -174,7 +178,7 @@ function outputChangelog (argv, cb) {
   var content = ''
   var changelogStream = conventionalChangelog({
     preset: argv.conventionalChangelogPreset || 'angular'
-  }, undefined, {merges: null})
+  }, templateContext, {merges: null})
     .on('error', function (err) {
       return cb(err)
     })

--- a/test.js
+++ b/test.js
@@ -224,6 +224,22 @@ describe('cli', function () {
     })
   })
 
+  describe('with context', function () {
+    it('should use context.json', function () {
+      writePackageJson('1.0.1')
+
+      commit('feat: new context flag')
+      commit('fix: patch release')
+      execCli('--context ../context.json').code.should.equal(0)
+
+      var content = fs.readFileSync('CHANGELOG.md', 'utf-8')
+      content.should.include('](bitbucket/b/a/commits/')
+      content.should.match(/patch release/)
+      content.should.match(/new context flag/)
+      shell.exec('git tag').stdout.should.match(/1\.1\.0/)
+    })
+  })
+
   describe('post-bump hook', function () {
     it('should run the post-bump hook when provided', function () {
       writePackageJson('1.0.0')


### PR DESCRIPTION
Add a new context flag to pass context to conventional-changelog

`standard-version --context context.json`

**context.json:**
```json
{
  "issue": "issues",
  "commit": "commit",
  "referenceActions": [
   "close",
   "closes",
   "closed",
   "closing",
   "fix",
   "fixes",
   "fixed",
   "fixing"
 ],
 "issuePrefixes": [
   "#"
 ]
}
```